### PR TITLE
fix: panel control buttons not responding to clicks

### DIFF
--- a/ui/panel.js
+++ b/ui/panel.js
@@ -79,21 +79,29 @@ export const MediaIndicator = GObject.registerClass(
             let prevIcon = new St.Icon({ icon_name: 'media-skip-backward-symbolic', style_class: 'system-status-icon' });
             this.prevBtn = new St.Button({ child: prevIcon, style_class: 'media-ctrl-btn' });
             
-            this.prevBtn.connect('clicked', () => {
+            this.prevBtn.connect('button-press-event', () => Clutter.EVENT_STOP);
+            this.prevBtn.connect('button-release-event', (actor, event) => {
                 this.activeProxy?.controls().previous();
                 if (this._popup) this._popup.resetPosition();
+                return Clutter.EVENT_STOP;
             });
 
             this.playIcon = new St.Icon({ icon_name: 'media-playback-start-symbolic', style_class: 'system-status-icon' });
             this.playBtn = new St.Button({ child: this.playIcon, style_class: 'media-ctrl-btn' });
-            this.playBtn.connect('clicked', () => this.activeProxy?.controls().playPause());
+            this.playBtn.connect('button-press-event', () => Clutter.EVENT_STOP);
+            this.playBtn.connect('button-release-event', (actor, event) => {
+                this.activeProxy?.controls().playPause();
+                return Clutter.EVENT_STOP;
+            });
 
             let nextIcon = new St.Icon({ icon_name: 'media-skip-forward-symbolic', style_class: 'system-status-icon' });
             this.nextBtn = new St.Button({ child: nextIcon, style_class: 'media-ctrl-btn' });
             
-            this.nextBtn.connect('clicked', () => {
+            this.nextBtn.connect('button-press-event', () => Clutter.EVENT_STOP);
+            this.nextBtn.connect('button-release-event', (actor, event) => {
                 this.activeProxy?.controls().next();
                 if (this._popup) this._popup.resetPosition();
+                return Clutter.EVENT_STOP;
             });
 
             this.btnBox.add_child(this.prevBtn);


### PR DESCRIPTION
## Fix control buttons not responding to clicks in panel

Fixes #2

**Problem:**
Button click events were propagating to the parent `PanelMenu.Button`, causing the popup to expand instead of executing button actions.

**Solution:**
Added `button-press-event` handlers to all three control buttons (prev, play/pause, next) that return `Clutter.EVENT_STOP`, preventing event propagation to the parent container.

**Testing:**
Tested on Fedora 43 with GNOME 49.4 on Wayland. Control buttons now work correctly without expanding the popup.